### PR TITLE
Release FOCUS Scrub 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run lint
+        run: make lint
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,13 @@ jobs:
       - name: Run lint
         run: make lint
 
-      - name: Run tests
-        run: make test
+      - name: Run tests with coverage
+        run: make coverage
+
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 *.pyd
 .pytest_cache/
 .mypy_cache/
+.coverage
+coverage.xml
+htmlcov/
 dist/
 build/
 *.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
     hooks:
       # Run the linter
       - id: ruff
-        args: [--fix]
       # Run the formatter
       - id: ruff-format
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.15.2
     hooks:
       # Run the linter
       - id: ruff

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "python-envs.defaultEnvManager": "ms-python.python:poetry",
+    "python-envs.defaultPackageManager": "ms-python.python:poetry"
 }

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ test: pytest  ## Run pytest tests
 pytest:  ## Run pytest tests
 	poetry run pytest tests/ -v
 
+coverage:  ## Run tests with coverage report
+	poetry run pytest tests/
+
+coverage-html:  ## Generate HTML coverage report
+	poetry run pytest tests/
+	@echo "Coverage report generated in htmlcov/index.html"
+	@echo "Open with: open htmlcov/index.html"
+
 lint:  ## Run ruff linter
 	poetry run ruff check .
 
@@ -45,3 +53,5 @@ clean:  ## Clean up cache files
 	find . -type d -name ".pytest_cache" -exec rm -rf {} +
 	find . -type d -name ".mypy_cache" -exec rm -rf {} +
 	find . -type d -name ".ruff_cache" -exec rm -rf {} +
+	rm -rf htmlcov/
+	rm -f .coverage coverage.xml

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Python command-line tool for scrubbing sensitive data from FOCUS billing files
 
 ### File Format Support
 - **Input formats**: `.csv`, `.csv.gz`, `.parquet`
-- **Output formats**: `csv-gzip`, `parquet`
+- **Output formats**: `csv-gzip`, `parquet`, `sql`
 - Process single files or entire directories
 - Preserves directory structure in output
 
@@ -117,6 +117,64 @@ poetry run focus-scrub input/ output/ \
   --dataset CostAndUsage \
   --output-format csv-gzip
 ```
+
+Available formats:
+- `parquet` (default): Apache Parquet columnar format
+- `csv-gzip`: Compressed CSV files
+- `sql`: SQL INSERT statements for database loading
+
+#### SQL Output Format
+
+The SQL output format generates CREATE TABLE DDL and bulk INSERT statements optimized for database loading:
+
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --output-format sql
+```
+
+**Features:**
+- Generates CREATE TABLE IF NOT EXISTS statement with inferred column types
+- Adds auto-incrementing `id` column as primary key
+- Generates bulk INSERT statements (1000 rows per batch)
+- Automatically derives table name from filename (sanitizes hyphens, spaces, periods → underscores)
+- Properly escapes single quotes in string values
+- Handles NULL values correctly
+- Includes row count in header comments
+
+**Example output:**
+```sql
+-- FOCUS Scrubbed Data
+-- Table: focus_data
+-- Rows: 2500
+
+CREATE TABLE IF NOT EXISTS focus_data (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  BillingAccountId TEXT,
+  BillingAccountName TEXT,
+  Cost DOUBLE PRECISION
+);
+
+INSERT INTO focus_data (BillingAccountId, BillingAccountName, Cost)
+VALUES
+  ('123456789012', 'Nebula Alpha', 100.50),
+  ('987654321098', 'Stellar Beta', 250.75),
+  ...;
+
+INSERT INTO focus_data (BillingAccountId, BillingAccountName, Cost)
+VALUES
+  ...
+```
+
+**Column type mapping:**
+- Integer columns → `BIGINT`
+- Float/Double columns → `DOUBLE PRECISION`
+- Boolean columns → `BOOLEAN`
+- DateTime columns → `TIMESTAMP`
+- Date columns → `DATE`
+- All other types → `TEXT`
+
+**Use case:** Ideal for loading scrubbed data directly into databases (PostgreSQL, MySQL, SQLite, etc.) using standard SQL import tools. The CREATE TABLE statement ensures the table exists before inserting data, and the auto-incrementing primary key provides a unique identifier for each row.
 
 ### Remove Custom Columns
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A Python command-line tool for scrubbing sensitive data from FOCUS billing files
 - **Name Anonymization**: Replaces account names with stellar-themed generated names
 - **Date Shifting**: Shifts date/datetime values by a configurable number of days
 - **Commitment Discount IDs**: Intelligently scrubs complex IDs containing embedded account numbers and UUIDs
+- **Tag Scrubbing**: Scrambles tag values while preserving keys by default; optionally scrambles keys as well
+- **Resource ID Scrubbing**: Handles AWS ARNs, Azure Resource IDs, and OCI OCIDs with intelligent pattern-based scrambling
 
 ### Mapping Engine
 - **Component-Level Mappings**: Centralized mapping engine ensures consistency across all columns
@@ -159,6 +161,29 @@ poetry run focus-scrub input/ output/ \
   --remove-custom-columns \
   --drop-columns x_Discounts  # Redundant but harmless
 ```
+
+### Scrub Tag Keys
+
+By default, the Tags column handler preserves tag keys and only scrubs the values. To also scrub the tag keys:
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --scrub-tag-keys
+```
+
+**Default behavior (preserve keys):**
+```
+Input:  {"environment":"production","owner":"team-alpha"}
+Output: {"environment":"qspcvdujpo","owner":"ufbn-bmqib"}
+```
+
+**With --scrub-tag-keys (scrub both keys and values):**
+```
+Input:  {"environment":"production","owner":"team-alpha"}
+Output: {"fowjsponfou":"qspcvdujpo","pxofs":"ufbn-bmqib"}
+```
+
+> **Note**: When `--scrub-tag-keys` is enabled, the same key will consistently map to the same scrambled key across all tags and all rows, ensuring referential integrity is maintained.
 
 ### Complete Example
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ A Python command-line tool for scrubbing sensitive data from FOCUS billing files
 - **Tag Scrubbing**: Scrambles tag values while preserving keys by default; optionally scrambles keys as well
 - **Resource ID Scrubbing**: Handles AWS ARNs, Azure Resource IDs, and OCI OCIDs with intelligent pattern-based scrambling
 
+#### What is NOT Scrubbed
+
+**Metric columns (costs, quantities, usage amounts) are intentionally left unchanged.** This is a deliberate design decision for the following reasons:
+
+1. **Interdependency Complexity**: Metric columns are mathematically related (e.g., `BilledCost = ConsumedQuantity × UnitPrice`). Adjusting one metric would require proportional adjustments to maintain consistency, which is extremely complex across all FOCUS metric relationships.
+
+2. **Reversibility Risk**: Any systematic scaling of metrics could potentially be reversed by correlating the scrubbed dataset with publicly available pricing data, providing a false sense of security without actual data protection.
+
+3. **Data Integrity**: Altering metrics would break the mathematical consistency of the dataset, making it unsuitable for realistic testing, validation, or development scenarios where accurate cost calculations are required.
+
+4. **Limited PII Value**: Unlike account IDs and names, aggregate cost and usage metrics typically don't constitute personally identifiable information on their own.
+
+**Recommendation**: If metric values are sensitive in your use case, consider using a representative subset of your data, applying additional manual obfuscation, or generating synthetic data with realistic distributions rather than relying on automated metric scrubbing.
+
 ### Mapping Engine
 - **Component-Level Mappings**: Centralized mapping engine ensures consistency across all columns
   - `NumberId`: Maps numeric IDs (e.g., 12-digit AWS account IDs)
@@ -407,6 +421,8 @@ make coverage-html
 This creates an interactive HTML report in `htmlcov/index.html` that you can open in your browser to see detailed line-by-line coverage information.
 
 **Current coverage:** ~89%
+
+**Coverage requirement:** The test suite enforces a minimum coverage threshold of **80%**. Tests will fail if coverage drops below this threshold, both locally and in CI/CD pipelines. This ensures code quality is maintained as the project evolves.
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,30 @@ VALUES
 
 **Use case:** Ideal for loading scrubbed data directly into databases (PostgreSQL, MySQL, SQLite, etc.) using standard SQL import tools. The CREATE TABLE statement ensures the table exists before inserting data, and the auto-incrementing primary key provides a unique identifier for each row.
 
+##### Custom Table Name
+
+By default, the SQL table name is derived from the input filename. You can specify a custom table name using the `--sql-table-name` option:
+
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --output-format sql \
+  --sql-table-name my_billing_data
+```
+
+This will generate SQL with your custom table name:
+```sql
+CREATE TABLE IF NOT EXISTS my_billing_data (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  ...
+);
+
+INSERT INTO my_billing_data (...)
+VALUES ...;
+```
+
+**Note:** The custom table name is still sanitized (hyphens, spaces, periods → underscores) to ensure SQL compatibility.
+
 ### Remove Custom Columns
 
 Remove custom columns (starting with `x_` or `oci_`) from the output:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,31 @@ Output: {"fowjsponfou":"qspcvdujpo","pxofs":"ufbn-bmqib"}
 
 > **Note**: When `--scrub-tag-keys` is enabled, the same key will consistently map to the same scrambled key across all tags and all rows, ensuring referential integrity is maintained.
 
+### Dates Only Mode
+
+To only shift dates without scrubbing any other sensitive data, use the `--dates-only` option. This is useful for re-dating FOCUS datasets for testing or analysis while preserving the original data:
+
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --date-shift-days 30 \
+  --dates-only
+```
+
+**What happens:**
+- Date columns are shifted by the specified number of days
+- All other columns (account IDs, names, tags, etc.) remain unchanged
+- Useful for time-based testing without data scrubbing
+
+**Example use case:**
+```bash
+# Re-date a dataset to current month for demo purposes
+poetry run focus-scrub historical_data/ demo_data/ \
+  --dataset CostAndUsage \
+  --date-shift-days 365 \
+  --dates-only
+```
+
 ### Complete Example
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -127,6 +127,39 @@ poetry run focus-scrub input/ output/ \
 
 > **Note**: The FOCUS spec states that custom columns should start with `x_`, but OCI uses `oci_` prefix. Both patterns are recognized and removed when this option is enabled.
 
+### Drop Specific Columns
+
+By default, the `x_Discounts` column is automatically dropped from the output. This is a known data generator custom column that is commonly removed.
+
+To keep `x_Discounts`, explicitly pass an empty list:
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --drop-columns
+```
+
+To drop additional specific columns:
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --drop-columns x_Discounts x_CustomField x_AnotherField
+```
+
+This is useful when you want to remove specific custom columns but keep others. For example, to drop only `x_CustomField` while keeping `x_Discounts`:
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --drop-columns x_CustomField
+```
+
+You can combine `--drop-columns` with `--remove-custom-columns`, though the latter will remove all custom columns anyway:
+```bash
+poetry run focus-scrub input/ output/ \
+  --dataset CostAndUsage \
+  --remove-custom-columns \
+  --drop-columns x_Discounts  # Redundant but harmless
+```
+
 ### Complete Example
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -375,3 +375,79 @@ CommitmentDiscountId: arn:aws:ec2:us-east-1:752426551655:reserved-instances/c741
 ```
 
 Note: The account ID `658755425446` consistently maps to `752426551655` in both the `SubAccountId` column and within the `CommitmentDiscountId` ARN.
+
+## Development
+
+### Running Tests
+
+Run the test suite:
+```bash
+make test
+# or
+poetry run pytest tests/ -v
+```
+
+### Code Coverage
+
+Run tests with coverage report:
+```bash
+make coverage
+```
+
+This will run all tests and display a coverage report in the terminal showing:
+- Overall coverage percentage
+- Coverage by file
+- Missing line numbers
+
+Generate an HTML coverage report:
+```bash
+make coverage-html
+```
+
+This creates an interactive HTML report in `htmlcov/index.html` that you can open in your browser to see detailed line-by-line coverage information.
+
+**Current coverage:** ~89%
+
+### Code Quality
+
+Run all code quality checks:
+```bash
+make check
+```
+
+This runs:
+- Linting (ruff)
+- Format checking (ruff format)
+- Type checking (mypy)
+- Tests with coverage
+
+Format code:
+```bash
+make format
+```
+
+### Pre-commit Hooks
+
+Install pre-commit hooks to automatically run checks before each commit:
+```bash
+make pre-commit-install
+```
+
+Or run manually:
+```bash
+make pre-commit-run
+```
+
+### Clean Up
+
+Remove generated files and caches:
+```bash
+make clean
+```
+
+This removes:
+- Python cache files (`__pycache__`, `.pyc`)
+- Test cache (`.pytest_cache`)
+- Type checking cache (`.mypy_cache`)
+- Linter cache (`.ruff_cache`)
+- Coverage files (`.coverage`, `coverage.xml`, `htmlcov/`)

--- a/focus_scrub/focus_scrub/cli.py
+++ b/focus_scrub/focus_scrub/cli.py
@@ -86,6 +86,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Only shift dates, leave all other data unchanged. Useful for re-dating datasets without scrubbing.",
     )
+    parser.add_argument(
+        "--sql-table-name",
+        type=str,
+        default=None,
+        help="Custom table name for SQL output. If not provided, derives from filename.",
+    )
     return parser
 
 
@@ -104,6 +110,7 @@ def main() -> int:
     drop_columns: list[str] = args.drop_columns
     scrub_tag_keys: bool = args.scrub_tag_keys
     dates_only: bool = args.dates_only
+    sql_table_name: str | None = args.sql_table_name
 
     files = discover_focus_files(input_path)
     if not files:
@@ -143,7 +150,7 @@ def main() -> int:
             output_root=output_path,
             output_format=output_format,
         )
-        write_focus_file(scrubbed, destination, output_format)
+        write_focus_file(scrubbed, destination, output_format, sql_table_name=sql_table_name)
         print(f"Processed: {input_file} -> {destination}")
 
     print(f"Done. Processed {len(files)} file(s) for dataset '{dataset}'.")

--- a/focus_scrub/focus_scrub/cli.py
+++ b/focus_scrub/focus_scrub/cli.py
@@ -76,6 +76,11 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="COLUMN",
         help="Specific column names to drop from the output (default: x_Discounts). Pass empty list to keep all columns.",
     )
+    parser.add_argument(
+        "--scrub-tag-keys",
+        action="store_true",
+        help="Scrub tag keys in addition to tag values (default: False, only scrubs values).",
+    )
     return parser
 
 
@@ -92,13 +97,14 @@ def main() -> int:
     load_mappings: Path | None = args.load_mappings
     remove_custom_columns: bool = args.remove_custom_columns
     drop_columns: list[str] = args.drop_columns
+    scrub_tag_keys: bool = args.scrub_tag_keys
 
     files = discover_focus_files(input_path)
     if not files:
         parser.error("No supported input files found (.csv, .csv.gz, .parquet).")
 
     collector = MappingCollector() if export_mappings is not None else None
-    handler_config = HandlerConfig(date_shift_days=date_shift_days)
+    handler_config = HandlerConfig(date_shift_days=date_shift_days, scrub_tag_keys=scrub_tag_keys)
 
     # Load existing mappings if provided
     mapping_engine = None

--- a/focus_scrub/focus_scrub/cli.py
+++ b/focus_scrub/focus_scrub/cli.py
@@ -69,6 +69,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Remove custom columns from the output.",
     )
+    parser.add_argument(
+        "--drop-columns",
+        nargs="*",
+        default=["x_Discounts"],
+        metavar="COLUMN",
+        help="Specific column names to drop from the output (default: x_Discounts). Pass empty list to keep all columns.",
+    )
     return parser
 
 
@@ -84,6 +91,7 @@ def main() -> int:
     export_mappings: Path | None = args.export_mappings
     load_mappings: Path | None = args.load_mappings
     remove_custom_columns: bool = args.remove_custom_columns
+    drop_columns: list[str] = args.drop_columns
 
     files = discover_focus_files(input_path)
     if not files:
@@ -107,7 +115,9 @@ def main() -> int:
         dataset, config=handler_config, collector=collector, mapping_engine=mapping_engine
     )
     scrub = DataFrameScrub(
-        column_handlers=column_handlers, remove_custom_columns=remove_custom_columns
+        column_handlers=column_handlers,
+        remove_custom_columns=remove_custom_columns,
+        drop_columns=drop_columns,
     )
 
     for input_file in files:

--- a/focus_scrub/focus_scrub/cli.py
+++ b/focus_scrub/focus_scrub/cli.py
@@ -81,6 +81,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Scrub tag keys in addition to tag values (default: False, only scrubs values).",
     )
+    parser.add_argument(
+        "--dates-only",
+        action="store_true",
+        help="Only shift dates, leave all other data unchanged. Useful for re-dating datasets without scrubbing.",
+    )
     return parser
 
 
@@ -98,13 +103,16 @@ def main() -> int:
     remove_custom_columns: bool = args.remove_custom_columns
     drop_columns: list[str] = args.drop_columns
     scrub_tag_keys: bool = args.scrub_tag_keys
+    dates_only: bool = args.dates_only
 
     files = discover_focus_files(input_path)
     if not files:
         parser.error("No supported input files found (.csv, .csv.gz, .parquet).")
 
     collector = MappingCollector() if export_mappings is not None else None
-    handler_config = HandlerConfig(date_shift_days=date_shift_days, scrub_tag_keys=scrub_tag_keys)
+    handler_config = HandlerConfig(
+        date_shift_days=date_shift_days, scrub_tag_keys=scrub_tag_keys, dates_only=dates_only
+    )
 
     # Load existing mappings if provided
     mapping_engine = None

--- a/focus_scrub/focus_scrub/handlers.py
+++ b/focus_scrub/focus_scrub/handlers.py
@@ -524,6 +524,7 @@ class TagsHandler:
     """
 
     mapping_engine: MappingEngine
+    scrub_tag_keys: bool = False
     _char_map: dict[str, str] = field(default_factory=dict, init=False, repr=False)
     _column_name: str = field(default="", init=False, repr=False)
     _collector: MappingCollector | None = field(default=None, init=False, repr=False)
@@ -568,8 +569,13 @@ class TagsHandler:
         if isinstance(value, list):
             if not value:  # Empty list
                 return value
-            # Scramble values but keep keys
-            scrubbed_list = [(key, self._scramble_string(val)) for key, val in value]
+            # Scramble values and optionally keys
+            if self.scrub_tag_keys:
+                scrubbed_list = [
+                    (self._scramble_string(key), self._scramble_string(val)) for key, val in value
+                ]
+            else:
+                scrubbed_list = [(key, self._scramble_string(val)) for key, val in value]
             if self._collector is not None:
                 self._collector.record(self._column_name, str(value), str(scrubbed_list))
             return scrubbed_list
@@ -578,9 +584,15 @@ class TagsHandler:
         if isinstance(value, dict):
             if not value:  # Empty dict
                 return value
-            scrubbed_dict = {
-                key: self._scramble_string(val) if val else val for key, val in value.items()
-            }
+            if self.scrub_tag_keys:
+                scrubbed_dict = {
+                    self._scramble_string(key): self._scramble_string(val) if val else val
+                    for key, val in value.items()
+                }
+            else:
+                scrubbed_dict = {
+                    key: self._scramble_string(val) if val else val for key, val in value.items()
+                }
             if self._collector is not None:
                 self._collector.record(self._column_name, str(value), str(scrubbed_dict))
             return scrubbed_dict
@@ -600,19 +612,33 @@ class TagsHandler:
             if original.startswith("["):
                 tags_list = ast.literal_eval(original)
                 if isinstance(tags_list, list):
-                    # Scramble values but keep keys
-                    scrubbed_list = [(key, self._scramble_string(val)) for key, val in tags_list]
+                    # Scramble values and optionally keys
+                    if self.scrub_tag_keys:
+                        scrubbed_list = [
+                            (self._scramble_string(key), self._scramble_string(val))
+                            for key, val in tags_list
+                        ]
+                    else:
+                        scrubbed_list = [
+                            (key, self._scramble_string(val)) for key, val in tags_list
+                        ]
                     replacement = str(scrubbed_list)
                 else:
                     replacement = original
             # Azure/OCI format: JSON string
             elif original.startswith("{"):
                 tags_dict = json.loads(original)
-                # Scramble values but keep keys
-                scrubbed_dict = {
-                    key: self._scramble_string(val) if val else val
-                    for key, val in tags_dict.items()
-                }
+                # Scramble values and optionally keys
+                if self.scrub_tag_keys:
+                    scrubbed_dict = {
+                        self._scramble_string(key): self._scramble_string(val) if val else val
+                        for key, val in tags_dict.items()
+                    }
+                else:
+                    scrubbed_dict = {
+                        key: self._scramble_string(val) if val else val
+                        for key, val in tags_dict.items()
+                    }
                 replacement = json.dumps(scrubbed_dict, separators=(",", ":"))
             else:
                 # Unknown format, pass through
@@ -635,6 +661,7 @@ class TagsHandler:
 @dataclass(frozen=True)
 class HandlerConfig:
     date_shift_days: int = 0
+    scrub_tag_keys: bool = False
 
 
 HandlerFactory = Callable[[HandlerConfig, MappingEngine], ColumnHandler]
@@ -663,7 +690,7 @@ def _build_resource_id_handler(config: HandlerConfig, engine: MappingEngine) -> 
 
 
 def _build_tags_handler(config: HandlerConfig, engine: MappingEngine) -> ColumnHandler:
-    return TagsHandler(mapping_engine=engine)
+    return TagsHandler(mapping_engine=engine, scrub_tag_keys=config.scrub_tag_keys)
 
 
 HANDLER_FACTORIES: dict[str, HandlerFactory] = {

--- a/focus_scrub/focus_scrub/handlers.py
+++ b/focus_scrub/focus_scrub/handlers.py
@@ -662,6 +662,7 @@ class TagsHandler:
 class HandlerConfig:
     date_shift_days: int = 0
     scrub_tag_keys: bool = False
+    dates_only: bool = False
 
 
 HandlerFactory = Callable[[HandlerConfig, MappingEngine], ColumnHandler]
@@ -758,6 +759,10 @@ def get_column_handlers_for_dataset(
         mapping_engine = MappingEngine()
 
     for column_name, handler_name in column_to_handler_name.items():
+        # If dates_only mode, skip non-date handlers
+        if config.dates_only and handler_name != "DateReformat":
+            continue
+
         if handler_name not in HANDLER_FACTORIES:
             raise ValueError(
                 f"Dataset '{dataset_name}' references unknown handler "

--- a/focus_scrub/focus_scrub/handlers.py
+++ b/focus_scrub/focus_scrub/handlers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import re
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
@@ -653,6 +654,40 @@ class TagsHandler:
         return replacement
 
 
+@dataclass
+class UnmappedScrambleStringHandler:
+    """Deterministically scramble string character order without storing mappings."""
+
+    def attach_collector(self, column_name: str, collector: MappingCollector) -> None:
+        # Intentionally a no-op: this handler should not emit mapping records.
+        return
+
+    def scrub(self, value: object) -> object:
+        try:
+            if pd.isna(value):
+                return value
+        except (ValueError, TypeError):
+            pass
+
+        original = str(value)
+        if len(original) <= 1:
+            return original
+
+        indices = list(range(len(original)))
+        sorted_indices = sorted(
+            indices,
+            key=lambda idx: hashlib.sha256(f"{original}|{idx}".encode()).digest(),
+        )
+        scrambled = "".join(original[idx] for idx in sorted_indices)
+
+        if scrambled == original:
+            rotated = original[1:] + original[0]
+            if rotated != original:
+                return rotated
+
+        return scrambled
+
+
 # ---------------------------------------------------------------------------
 # Handler config + factories
 # ---------------------------------------------------------------------------
@@ -694,6 +729,12 @@ def _build_tags_handler(config: HandlerConfig, engine: MappingEngine) -> ColumnH
     return TagsHandler(mapping_engine=engine, scrub_tag_keys=config.scrub_tag_keys)
 
 
+def _build_unmapped_scamble_string_handler(
+    config: HandlerConfig, engine: MappingEngine
+) -> ColumnHandler:
+    return UnmappedScrambleStringHandler()
+
+
 HANDLER_FACTORIES: dict[str, HandlerFactory] = {
     "DateReformat": _build_date_reformat_handler,
     "AccountId": _build_account_id_handler,
@@ -701,6 +742,8 @@ HANDLER_FACTORIES: dict[str, HandlerFactory] = {
     "CommitmentDiscountId": _build_commitment_discount_id_handler,
     "ResourceId": _build_resource_id_handler,
     "Tags": _build_tags_handler,
+    "unmapped_scamble_string": _build_unmapped_scamble_string_handler,
+    "UnmappedScrambleString": _build_unmapped_scamble_string_handler,
 }
 
 # Dataset-specific column mapping.
@@ -719,6 +762,15 @@ DATASET_COLUMN_HANDLER_NAMES: dict[str, dict[str, str]] = {
         "CommitmentDiscountId": "CommitmentDiscountId",
         "ResourceId": "ResourceId",
         "Tags": "Tags",
+        "oci_ReferenceNumber": "unmapped_scamble_string",
+        "oci_CompartmentId": "ResourceId",
+        "oci_CompartmentName": "StellarName",
+        "x_BillingAccountName": "StellarName",
+        "x_BillingAccountId": "AccountId",
+        "x_BillingProfileId": "AccountId",
+        "x_CustomerName": "StellarName",
+        "x_InvoiceSectionId": "AccountId",
+        "x_ResourceGroupName": "StellarName",
     },
     "ContractCommitment": {
         "ContractCommitmentPeriodStart": "DateReformat",

--- a/focus_scrub/focus_scrub/io.py
+++ b/focus_scrub/focus_scrub/io.py
@@ -35,7 +35,8 @@ def read_focus_file(path: Path) -> pd.DataFrame:
         return pd.read_parquet(path)
 
     if suffixes[-2:] == [".csv", ".gz"] or path.suffix == ".csv":
-        return pd.read_csv(path)
+        # Avoid mixed-type chunk inference warnings on large FOCUS CSV files.
+        return pd.read_csv(path, low_memory=False)
 
     raise ValueError(f"Unsupported input format: {path}")
 

--- a/focus_scrub/focus_scrub/io.py
+++ b/focus_scrub/focus_scrub/io.py
@@ -9,6 +9,7 @@ import pandas as pd
 class FileFormat(str, Enum):
     CSV_GZIP = "csv-gzip"
     PARQUET = "parquet"
+    SQL = "sql"
 
 
 SUPPORTED_INPUT_EXTENSIONS: tuple[str, ...] = (".csv", ".csv.gz", ".parquet")
@@ -56,6 +57,8 @@ def output_path_for_file(
 
     if output_format == FileFormat.CSV_GZIP:
         return output_root / f"{base}.csv.gz"
+    if output_format == FileFormat.SQL:
+        return output_root / f"{base}.sql"
     return output_root / f"{base}.parquet"
 
 
@@ -70,6 +73,10 @@ def write_focus_file(df: pd.DataFrame, output_file: Path, output_format: FileFor
         df.to_parquet(output_file, index=False)
         return
 
+    if output_format == FileFormat.SQL:
+        _write_sql_insert_statements(df, output_file)
+        return
+
     raise ValueError(f"Unsupported output format: {output_format}")
 
 
@@ -80,7 +87,117 @@ def _is_supported_input_file(path: Path) -> bool:
 
 def _strip_known_extensions(path: Path) -> str:
     text = str(path)
-    for suffix in (".csv.gz", ".parquet", ".csv"):
+    for suffix in (".csv.gz", ".parquet", ".csv", ".sql"):
         if text.lower().endswith(suffix):
             return text[: -len(suffix)]
     return text
+
+
+def _pandas_dtype_to_sql_type(dtype: str) -> str:
+    """Map pandas dtype to SQL type."""
+    dtype_str = str(dtype).lower()
+
+    if "int" in dtype_str:
+        return "BIGINT"
+    elif "float" in dtype_str or "double" in dtype_str:
+        return "DOUBLE PRECISION"
+    elif "bool" in dtype_str:
+        return "BOOLEAN"
+    elif "datetime" in dtype_str or "timestamp" in dtype_str:
+        return "TIMESTAMP"
+    elif "date" in dtype_str:
+        return "DATE"
+    else:
+        # Default to TEXT for strings and other types
+        return "TEXT"
+
+
+def _write_sql_insert_statements(df: pd.DataFrame, output_file: Path) -> None:
+    """Write DataFrame as SQL CREATE TABLE and INSERT statements.
+
+    Generates CREATE TABLE DDL and bulk INSERT statements with proper SQL escaping.
+    Table name is derived from the output filename.
+    """
+    # Derive table name from filename (without extension)
+    table_name = output_file.stem
+    # Sanitize table name (replace hyphens/spaces/periods with underscores)
+    table_name = table_name.replace("-", "_").replace(" ", "_").replace(".", "_")
+
+    with open(output_file, "w") as f:
+        # Write header comment
+        f.write("-- FOCUS Scrubbed Data\n")
+        f.write(f"-- Table: {table_name}\n")
+        f.write(f"-- Rows: {len(df)}\n\n")
+
+        # Get column names and types
+        columns = df.columns.tolist()
+
+        # Write CREATE TABLE statement
+        f.write(f"CREATE TABLE IF NOT EXISTS {table_name} (\n")
+        column_defs = ["  id BIGINT AUTO_INCREMENT PRIMARY KEY"]
+        for col in columns:
+            sql_type = _pandas_dtype_to_sql_type(df[col].dtype)
+            column_defs.append(f"  {col} {sql_type}")
+        f.write(",\n".join(column_defs))
+        f.write("\n);\n\n")
+
+        if len(df) == 0:
+            f.write("-- No data to insert\n")
+            return
+
+        # Column list for INSERT statements
+        column_list = ", ".join(f"{col}" for col in columns)
+
+        # Write bulk INSERT in batches of 1000 rows
+        batch_size = 1000
+        for batch_start in range(0, len(df), batch_size):
+            batch_end = min(batch_start + batch_size, len(df))
+            batch_df = df.iloc[batch_start:batch_end]
+
+            f.write(f"INSERT INTO {table_name} ({column_list})\n")
+            f.write("VALUES\n")
+
+            for idx, (_, row) in enumerate(batch_df.iterrows()):
+                values = []
+                for col in columns:
+                    value = row[col]
+                    # Handle different data types
+                    try:
+                        is_na = pd.isna(value)
+                        # If pd.isna returns an array, treat as not NA
+                        if hasattr(is_na, "__len__") and not isinstance(is_na, str):
+                            is_na = False
+                    except (ValueError, TypeError):
+                        # For array-like values, pd.isna() may fail
+                        is_na = False
+
+                    if is_na:
+                        values.append("NULL")
+                    elif isinstance(value, (int, float)):
+                        # Check if it's actually NaN
+                        try:
+                            is_na_num = pd.isna(value)
+                            if hasattr(is_na_num, "__len__") and not isinstance(is_na_num, str):
+                                is_na_num = False
+                        except (ValueError, TypeError):
+                            is_na_num = False
+
+                        if is_na_num:
+                            values.append("NULL")
+                        else:
+                            values.append(str(value))
+                    elif isinstance(value, str):
+                        # Escape single quotes
+                        escaped = value.replace("'", "''")
+                        values.append(f"'{escaped}'")
+                    else:
+                        # For other types (e.g., lists, dicts), convert to string
+                        escaped = str(value).replace("'", "''")
+                        values.append(f"'{escaped}'")
+
+                value_list = ", ".join(values)
+                # Add comma if not the last row in batch
+                if idx < len(batch_df) - 1:
+                    f.write(f"  ({value_list}),\n")
+                else:
+                    f.write(f"  ({value_list});\n\n")

--- a/focus_scrub/focus_scrub/io.py
+++ b/focus_scrub/focus_scrub/io.py
@@ -62,7 +62,12 @@ def output_path_for_file(
     return output_root / f"{base}.parquet"
 
 
-def write_focus_file(df: pd.DataFrame, output_file: Path, output_format: FileFormat) -> None:
+def write_focus_file(
+    df: pd.DataFrame,
+    output_file: Path,
+    output_format: FileFormat,
+    sql_table_name: str | None = None,
+) -> None:
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
     if output_format == FileFormat.CSV_GZIP:
@@ -74,7 +79,7 @@ def write_focus_file(df: pd.DataFrame, output_file: Path, output_format: FileFor
         return
 
     if output_format == FileFormat.SQL:
-        _write_sql_insert_statements(df, output_file)
+        _write_sql_insert_statements(df, output_file, sql_table_name)
         return
 
     raise ValueError(f"Unsupported output format: {output_format}")
@@ -112,14 +117,19 @@ def _pandas_dtype_to_sql_type(dtype: str) -> str:
         return "TEXT"
 
 
-def _write_sql_insert_statements(df: pd.DataFrame, output_file: Path) -> None:
+def _write_sql_insert_statements(
+    df: pd.DataFrame, output_file: Path, sql_table_name: str | None = None
+) -> None:
     """Write DataFrame as SQL CREATE TABLE and INSERT statements.
 
     Generates CREATE TABLE DDL and bulk INSERT statements with proper SQL escaping.
-    Table name is derived from the output filename.
+    Table name is derived from the output filename unless sql_table_name is provided.
     """
-    # Derive table name from filename (without extension)
-    table_name = output_file.stem
+    # Use custom table name if provided, otherwise derive from filename
+    if sql_table_name:
+        table_name = sql_table_name
+    else:
+        table_name = output_file.stem
     # Sanitize table name (replace hyphens/spaces/periods with underscores)
     table_name = table_name.replace("-", "_").replace(" ", "_").replace(".", "_")
 

--- a/focus_scrub/focus_scrub/mapping/__init__.py
+++ b/focus_scrub/focus_scrub/mapping/__init__.py
@@ -3,4 +3,5 @@
 from focus_scrub.mapping.collector import MappingCollector
 from focus_scrub.mapping.engine import MappingEngine
 
+
 __all__ = ["MappingCollector", "MappingEngine"]

--- a/focus_scrub/focus_scrub/scrub.py
+++ b/focus_scrub/focus_scrub/scrub.py
@@ -13,10 +13,15 @@ class DataFrameScrub:
     """Applies configured handlers per column."""
 
     def __init__(
-        self, column_handlers: dict[str, ColumnHandler], remove_custom_columns: bool = False
+        self,
+        column_handlers: dict[str, ColumnHandler],
+        remove_custom_columns: bool = False,
+        drop_columns: list[str] | None = None,
     ):
         self._column_handlers = column_handlers
         self._remove_custom_columns = remove_custom_columns
+        # Default to dropping x_Discounts if not specified
+        self._drop_columns = drop_columns if drop_columns is not None else ["x_Discounts"]
 
     def _is_custom_column(self, column_name: str) -> bool:
         """Check if a column is a custom column (x_* or oci_*)."""
@@ -30,6 +35,12 @@ class DataFrameScrub:
             custom_columns = [col for col in result.columns if self._is_custom_column(col)]
             if custom_columns:
                 result = result.drop(columns=custom_columns)
+
+        # Drop specific columns if requested
+        if self._drop_columns:
+            columns_to_drop = [col for col in self._drop_columns if col in result.columns]
+            if columns_to_drop:
+                result = result.drop(columns=columns_to_drop)
 
         # Apply handlers to remaining columns
         for column_name in result.columns:

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,6 +26,128 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.4"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "coverage-7.13.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0fc31c787a84f8cd6027eba44010517020e0d18487064cd3d8968941856d1415"},
+    {file = "coverage-7.13.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a32ebc02a1805adf637fc8dec324b5cdacd2e493515424f70ee33799573d661b"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e24f9156097ff9dc286f2f913df3a7f63c0e333dcafa3c196f2c18b4175ca09a"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8041b6c5bfdc03257666e9881d33b1abc88daccaf73f7b6340fb7946655cd10f"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a09cfa6a5862bc2fc6ca7c3def5b2926194a56b8ab78ffcf617d28911123012"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:296f8b0af861d3970c2a4d8c91d48eb4dd4771bcef9baedec6a9b515d7de3def"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e101609bcbbfb04605ea1027b10dc3735c094d12d40826a60f897b98b1c30256"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa3feb8db2e87ff5e6d00d7e1480ae241876286691265657b500886c98f38bda"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4fc7fa81bbaf5a02801b65346c8b3e657f1d93763e58c0abdf7c992addd81a92"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:33901f604424145c6e9c2398684b92e176c0b12df77d52db81c20abd48c3794c"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:bb28c0f2cf2782508a40cec377935829d5fcc3ad9a3681375af4e84eb34b6b58"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d107aff57a83222ddbd8d9ee705ede2af2cc926608b57abed8ef96b50b7e8f9"},
+    {file = "coverage-7.13.4-cp310-cp310-win32.whl", hash = "sha256:a6f94a7d00eb18f1b6d403c91a88fd58cfc92d4b16080dfdb774afc8294469bf"},
+    {file = "coverage-7.13.4-cp310-cp310-win_amd64.whl", hash = "sha256:2cb0f1e000ebc419632bbe04366a8990b6e32c4e0b51543a6484ffe15eaeda95"},
+    {file = "coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053"},
+    {file = "coverage-7.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e264226ec98e01a8e1054314af91ee6cde0eacac4f465cc93b03dbe0bce2fd7"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3aa4e7b9e416774b21797365b358a6e827ffadaaca81b69ee02946852449f00"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:71ca20079dd8f27fcf808817e281e90220475cd75115162218d0e27549f95fef"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e2f25215f1a359ab17320b47bcdaca3e6e6356652e8256f2441e4ef972052903"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d65b2d373032411e86960604dc4edac91fdfb5dca539461cf2cbe78327d1e64f"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94eb63f9b363180aff17de3e7c8760c3ba94664ea2695c52f10111244d16a299"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e856bf6616714c3a9fbc270ab54103f4e685ba236fa98c054e8f87f266c93505"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:65dfcbe305c3dfe658492df2d85259e0d79ead4177f9ae724b6fb245198f55d6"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b507778ae8a4c915436ed5c2e05b4a6cecfa70f734e19c22a005152a11c7b6a9"},
+    {file = "coverage-7.13.4-cp311-cp311-win32.whl", hash = "sha256:784fc3cf8be001197b652d51d3fd259b1e2262888693a4636e18879f613a62a9"},
+    {file = "coverage-7.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:2421d591f8ca05b308cf0092807308b2facbefe54af7c02ac22548b88b95c98f"},
+    {file = "coverage-7.13.4-cp311-cp311-win_arm64.whl", hash = "sha256:79e73a76b854d9c6088fe5d8b2ebe745f8681c55f7397c3c0a016192d681045f"},
+    {file = "coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459"},
+    {file = "coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0"},
+    {file = "coverage-7.13.4-cp312-cp312-win32.whl", hash = "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246"},
+    {file = "coverage-7.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126"},
+    {file = "coverage-7.13.4-cp312-cp312-win_arm64.whl", hash = "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d"},
+    {file = "coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9"},
+    {file = "coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a"},
+    {file = "coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d"},
+    {file = "coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd"},
+    {file = "coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af"},
+    {file = "coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d"},
+    {file = "coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b"},
+    {file = "coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9"},
+    {file = "coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd"},
+    {file = "coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997"},
+    {file = "coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601"},
+    {file = "coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0"},
+    {file = "coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb"},
+    {file = "coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505"},
+    {file = "coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2"},
+    {file = "coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056"},
+    {file = "coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0"},
+    {file = "coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea"},
+    {file = "coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932"},
+    {file = "coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b"},
+    {file = "coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0"},
+    {file = "coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91"},
+]
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 description = "Distribution utilities"
@@ -798,6 +920,26 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "7.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861"},
+    {file = "pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.10.6", extras = ["toml"]}
+pluggy = ">=1.2"
+pytest = ">=7"
+
+[package.extras]
+testing = ["process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1073,4 +1215,4 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "d80c4db914e716f28d891bbd2ceede80cafeca3e1c001dcdb10ff0fbd96c1a3c"
+content-hash = "af670cfe190d4f0a7ec7ca1c4cde4ded2d2b7a1288a86cfabfe2ccfdc84774ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ ignore = [
     "E501",  # line too long, handled by formatter
 ]
 
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pyarrow = ">=15.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
+pytest-cov = ">=5.0.0"
 ruff = ">=0.9.0"
 mypy = ">=1.14.0"
 pre-commit = ">=4.0.0"
@@ -48,6 +49,28 @@ lines-after-imports = 2
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.coverage.run]
+source = ["focus_scrub"]
+omit = [
+    "*/tests/*",
+    "*/__pycache__/*",
+    "*/venv/*",
+    "*/.venv/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+]
+precision = 2
+show_missing = true
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "focus-scrub"
-version = "0.1.0"
+version = "0.1.1"
 description = "Command-line FOCUS file scrub tool with pluggable per-column handlers."
 authors = []
 readme = "README.md"

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,11 @@ addopts =
     -v
     --strict-markers
     --tb=short
+    --cov=focus_scrub
+    --cov-report=term-missing
+    --cov-report=html
+    --cov-report=xml
+    --cov-fail-under=80
 markers =
     integration: Integration tests that test multiple components together
     unit: Unit tests for individual components

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from focus_scrub.mapping import MappingCollector, MappingEngine
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,432 @@
+"""Tests for CLI functionality."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+class TestCLI:
+    """Test CLI integration."""
+
+    def test_cli_basic_run(self) -> None:
+        """Test basic CLI execution."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            # Create a simple test file
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "BillingAccountName": ["TestAccount"],
+                    "BillingPeriodStart": ["2024-01-01T00:00:00Z"],
+                    "BillingPeriodEnd": ["2024-01-31T23:59:59Z"],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            # Run CLI
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+            ]
+
+            result = main()
+            assert result == 0
+
+            # Check output was created
+            output_files = list(output_dir.rglob("*.parquet"))
+            assert len(output_files) == 1
+
+    def test_cli_with_csv_gzip_output(self) -> None:
+        """Test CLI with CSV gzip output format."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.parquet"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "BillingAccountName": ["TestAccount"],
+                    "BillingPeriodStart": ["2024-01-01T00:00:00Z"],
+                    "BillingPeriodEnd": ["2024-01-31T23:59:59Z"],
+                }
+            )
+            df.to_parquet(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--output-format",
+                "csv-gzip",
+            ]
+
+            result = main()
+            assert result == 0
+
+            output_files = list(output_dir.rglob("*.csv.gz"))
+            assert len(output_files) == 1
+
+    def test_cli_with_date_shift(self) -> None:
+        """Test CLI with date shifting."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "BillingPeriodStart": ["2024-01-01T00:00:00Z"],
+                    "BillingPeriodEnd": ["2024-01-31T23:59:59Z"],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--date-shift-days",
+                "30",
+            ]
+
+            result = main()
+            assert result == 0
+
+    def test_cli_with_mappings_export(self) -> None:
+        """Test CLI with mappings export."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            mappings_file = Path(tmpdir) / "mappings.json"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012", "987654321098"],
+                    "BillingAccountName": ["TestAccount", "OtherAccount"],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--export-mappings",
+                str(mappings_file),
+            ]
+
+            result = main()
+            assert result == 0
+
+            # Check mappings file was created
+            assert mappings_file.exists()
+            mappings_data = json.loads(mappings_file.read_text())
+            assert "column_mappings" in mappings_data
+            assert "component_mappings" in mappings_data
+
+    def test_cli_with_mappings_load(self) -> None:
+        """Test CLI with loading mappings."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            mappings_file = Path(tmpdir) / "mappings.json"
+            input_dir.mkdir()
+
+            # Create mappings file
+            mappings_data = {
+                "column_mappings": {},
+                "component_mappings": {
+                    "number_id": {"123456789012": "999999999999"},
+                    "name": {"TestAccount": "MappedAccount"},
+                },
+            }
+            mappings_file.write_text(json.dumps(mappings_data))
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "BillingAccountName": ["TestAccount"],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--load-mappings",
+                str(mappings_file),
+            ]
+
+            result = main()
+            assert result == 0
+
+    def test_cli_with_remove_custom_columns(self) -> None:
+        """Test CLI with remove custom columns option."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "x_CustomColumn": ["value"],
+                    "oci_CustomColumn": ["value"],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--remove-custom-columns",
+            ]
+
+            result = main()
+            assert result == 0
+
+    def test_cli_with_drop_columns(self) -> None:
+        """Test CLI with drop columns option."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "x_Discounts": ["value"],
+                    "OtherColumn": ["value"],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--drop-columns",
+                "OtherColumn",
+            ]
+
+            result = main()
+            assert result == 0
+
+    def test_cli_with_scrub_tag_keys(self) -> None:
+        """Test CLI with scrub tag keys option."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "Tags": ['{"key": "value"}'],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--scrub-tag-keys",
+            ]
+
+            result = main()
+            assert result == 0
+
+    def test_cli_with_dates_only(self) -> None:
+        """Test CLI with dates only option."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "BillingPeriodStart": ["2024-01-01T00:00:00Z"],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--dates-only",
+            ]
+
+            result = main()
+            assert result == 0
+
+    def test_cli_with_sql_output_and_table_name(self) -> None:
+        """Test CLI with SQL output and custom table name."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame(
+                {
+                    "BillingAccountId": ["123456789012"],
+                    "Cost": [100.50],
+                }
+            )
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--output-format",
+                "sql",
+                "--sql-table-name",
+                "my_custom_table",
+            ]
+
+            result = main()
+            assert result == 0
+
+            output_files = list(output_dir.rglob("*.sql"))
+            assert len(output_files) == 1
+
+            sql_content = output_files[0].read_text()
+            assert "my_custom_table" in sql_content
+
+    def test_cli_no_input_files(self) -> None:
+        """Test CLI with no input files."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            input_dir.mkdir()
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+            ]
+
+            with pytest.raises(SystemExit):
+                main()
+
+    def test_cli_missing_mappings_file(self) -> None:
+        """Test CLI with missing mappings file."""
+        from focus_scrub.cli import main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            output_dir = Path(tmpdir) / "output"
+            mappings_file = Path(tmpdir) / "missing_mappings.json"
+            input_dir.mkdir()
+
+            test_file = input_dir / "test.csv"
+            df = pd.DataFrame({"BillingAccountId": ["123456789012"]})
+            df.to_csv(test_file, index=False)
+
+            import sys
+
+            sys.argv = [
+                "focus-scrub",
+                str(input_dir),
+                str(output_dir),
+                "--dataset",
+                "CostAndUsage",
+                "--load-mappings",
+                str(mappings_file),
+            ]
+
+            with pytest.raises(SystemExit):
+                main()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pandas as pd
-
 from focus_scrub.handlers import (
     AccountIdHandler,
     CommitmentDiscountIdHandler,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -9,6 +9,7 @@ from focus_scrub.handlers import (
     ResourceIdHandler,
     StellarNameHandler,
     TagsHandler,
+    UnmappedScrambleStringHandler,
 )
 from focus_scrub.mapping import MappingCollector, MappingEngine
 
@@ -622,3 +623,39 @@ class TestTagsHandler:
         keys1.sort()
         keys2.sort()
         assert keys1 == keys2, "Same original keys should produce same scrambled keys"
+
+
+class TestUnmappedScrambleStringHandler:
+    """Test the UnmappedScrambleStringHandler."""
+
+    def test_scrambles_character_order(self) -> None:
+        """Test that values are scrambled by reordering characters."""
+        handler = UnmappedScrambleStringHandler()
+
+        original = "ABCD-1234"
+        result = handler.scrub(original)
+
+        assert result != original
+        assert len(result) == len(original)
+        assert sorted(result) == sorted(original)
+
+    def test_deterministic_without_mapping_records(
+        self, mapping_collector: MappingCollector
+    ) -> None:
+        """Test deterministic output and no mapping collector side effects."""
+        handler = UnmappedScrambleStringHandler()
+        handler.attach_collector("oci_ReferenceNumber", mapping_collector)
+
+        original = "ref-number-0001"
+        result1 = handler.scrub(original)
+        result2 = handler.scrub(original)
+
+        assert result1 == result2
+        assert mapping_collector.to_dict() == {}
+
+    def test_na_values_passed_through(self) -> None:
+        """Test that NA values are passed through unchanged."""
+        handler = UnmappedScrambleStringHandler()
+
+        assert pd.isna(handler.scrub(pd.NA))
+        assert pd.isna(handler.scrub(None))

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -497,3 +497,128 @@ class TestTagsHandler:
         assert "Tags" in mappings
         assert original in dict(mappings["Tags"])
         assert dict(mappings["Tags"])[original] == result
+
+    def test_scrub_tag_keys_aws_format(self, mapping_engine: MappingEngine) -> None:
+        """Test that tag keys are scrambled when scrub_tag_keys=True (AWS format)."""
+        handler = TagsHandler(mapping_engine=mapping_engine, scrub_tag_keys=True)
+
+        tags = "[('environment', 'production'), ('owner', 'team-alpha')]"
+        result = handler.scrub(tags)
+
+        import ast
+
+        result_list = ast.literal_eval(result)
+
+        # Keys should be scrambled
+        keys = [key for key, _ in result_list]
+        assert "environment" not in keys
+        assert "owner" not in keys
+
+        # Values should be scrambled
+        values = [val for _, val in result_list]
+        assert "production" not in values
+        assert "team-alpha" not in values
+
+        # Should still be valid list of tuples
+        assert len(result_list) == 2
+        assert all(isinstance(item, tuple) and len(item) == 2 for item in result_list)
+
+    def test_scrub_tag_keys_json_format(self, mapping_engine: MappingEngine) -> None:
+        """Test that tag keys are scrambled when scrub_tag_keys=True (JSON format)."""
+        handler = TagsHandler(mapping_engine=mapping_engine, scrub_tag_keys=True)
+
+        tags = '{"environment":"production","owner":"team-alpha"}'
+        result = handler.scrub(tags)
+
+        import json
+
+        result_dict = json.loads(result)
+
+        # Keys should be scrambled (not original keys)
+        assert "environment" not in result_dict
+        assert "owner" not in result_dict
+
+        # Values should be scrambled
+        assert "production" not in result_dict.values()
+        assert "team-alpha" not in result_dict.values()
+
+        # Should still be valid dict with same number of entries
+        assert len(result_dict) == 2
+
+    def test_scrub_tag_keys_preserves_keys_by_default(self, mapping_engine: MappingEngine) -> None:
+        """Test that keys are preserved when scrub_tag_keys=False (default)."""
+        handler = TagsHandler(mapping_engine=mapping_engine, scrub_tag_keys=False)
+
+        tags = '{"environment":"production","owner":"team-alpha"}'
+        result = handler.scrub(tags)
+
+        import json
+
+        result_dict = json.loads(result)
+
+        # Keys should be preserved (default behavior)
+        assert "environment" in result_dict
+        assert "owner" in result_dict
+
+        # Values should be scrambled
+        assert result_dict["environment"] != "production"
+        assert result_dict["owner"] != "team-alpha"
+
+    def test_scrub_tag_keys_with_native_list(self, mapping_engine: MappingEngine) -> None:
+        """Test that native list objects have keys scrambled when scrub_tag_keys=True."""
+        handler = TagsHandler(mapping_engine=mapping_engine, scrub_tag_keys=True)
+
+        # Native Python list (from parquet)
+        tags = [("environment", "production"), ("owner", "team-alpha")]
+        result = handler.scrub(tags)
+
+        # Keys should be scrambled
+        keys = [key for key, _ in result]
+        assert "environment" not in keys
+        assert "owner" not in keys
+
+        # Values should be scrambled
+        values = [val for _, val in result]
+        assert "production" not in values
+        assert "team-alpha" not in values
+
+    def test_scrub_tag_keys_with_native_dict(self, mapping_engine: MappingEngine) -> None:
+        """Test that native dict objects have keys scrambled when scrub_tag_keys=True."""
+        handler = TagsHandler(mapping_engine=mapping_engine, scrub_tag_keys=True)
+
+        # Native Python dict
+        tags = {"environment": "production", "owner": "team-alpha"}
+        result = handler.scrub(tags)
+
+        # Keys should be scrambled
+        assert "environment" not in result
+        assert "owner" not in result
+
+        # Values should be scrambled
+        assert "production" not in result.values()
+        assert "team-alpha" not in result.values()
+
+    def test_scrub_tag_keys_consistency(self, mapping_engine: MappingEngine) -> None:
+        """Test that same keys scramble consistently when scrub_tag_keys=True."""
+        handler = TagsHandler(mapping_engine=mapping_engine, scrub_tag_keys=True)
+
+        tags1 = '{"env":"prod","team":"alpha"}'
+        tags2 = '{"env":"staging","team":"beta"}'
+
+        result1 = handler.scrub(tags1)
+        result2 = handler.scrub(tags2)
+
+        import json
+
+        dict1 = json.loads(result1)
+        dict2 = json.loads(result2)
+
+        # Same key should scramble to same value
+        keys1 = list(dict1.keys())
+        keys2 = list(dict2.keys())
+
+        # "env"  and "team" should map to the same scrambled keys in both
+        # We can verify by checking the scrambled keys match up by sorting
+        keys1.sort()
+        keys2.sort()
+        assert keys1 == keys2, "Same original keys should produce same scrambled keys"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pandas as pd
-
 from focus_scrub.handlers import HandlerConfig, get_column_handlers_for_dataset
 from focus_scrub.mapping import MappingCollector
 from focus_scrub.scrub import DataFrameScrub

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -300,3 +300,40 @@ class TestIntegration:
         assert "BillingAccountId" in result.columns
         assert "Tags" in result.columns
         assert len(result.columns) == 2
+
+    def test_scrub_tag_keys_config_option(self) -> None:
+        """Test that scrub_tag_keys config option works through the handler."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "Tags": ['{"environment":"production","owner":"team-alpha"}'],
+            }
+        )
+
+        # Default behavior: preserve keys
+        config_default = HandlerConfig(date_shift_days=0, scrub_tag_keys=False)
+        column_handlers_default, _ = get_column_handlers_for_dataset(
+            "CostAndUsage", config=config_default
+        )
+        scrub_default = DataFrameScrub(column_handlers=column_handlers_default)
+        result_default = scrub_default.scrub(df)
+
+        import json
+
+        result_tags_default = json.loads(result_default["Tags"][0])
+        assert "environment" in result_tags_default  # Keys preserved
+        assert "owner" in result_tags_default
+        assert result_tags_default["environment"] != "production"  # Values scrambled
+
+        # With scrub_tag_keys: scramble keys too
+        config_scrub = HandlerConfig(date_shift_days=0, scrub_tag_keys=True)
+        column_handlers_scrub, _ = get_column_handlers_for_dataset(
+            "CostAndUsage", config=config_scrub
+        )
+        scrub_keys = DataFrameScrub(column_handlers=column_handlers_scrub)
+        result_scrub = scrub_keys.scrub(df)
+
+        result_tags_scrub = json.loads(result_scrub["Tags"][0])
+        assert "environment" not in result_tags_scrub  # Keys scrambled
+        assert "owner" not in result_tags_scrub
+        assert "production" not in result_tags_scrub.values()  # Values also scrambled

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -337,3 +337,92 @@ class TestIntegration:
         assert "environment" not in result_tags_scrub  # Keys scrambled
         assert "owner" not in result_tags_scrub
         assert "production" not in result_tags_scrub.values()  # Values also scrambled
+
+    def test_dates_only_mode(self) -> None:
+        """Test that dates_only mode only shifts dates and leaves other data unchanged."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "BillingAccountName": ["Company A"],
+                "SubAccountId": ["222222222222"],
+                "BillingPeriodStart": ["2024-01-01T00:00:00Z"],
+                "BillingPeriodEnd": ["2024-01-31T23:59:59Z"],
+                "Tags": ['{"environment":"production"}'],
+            }
+        )
+
+        # With dates_only=True, only date columns should be processed
+        config = HandlerConfig(date_shift_days=30, dates_only=True)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        scrub = DataFrameScrub(column_handlers=column_handlers)
+
+        result = scrub.scrub(df)
+
+        # Account IDs should be unchanged
+        assert result["BillingAccountId"][0] == "111111111111"
+        assert result["SubAccountId"][0] == "222222222222"
+
+        # Account names should be unchanged
+        assert result["BillingAccountName"][0] == "Company A"
+
+        # Tags should be unchanged
+        assert result["Tags"][0] == '{"environment":"production"}'
+
+        # Dates should be shifted
+        assert result["BillingPeriodStart"][0] != "2024-01-01T00:00:00Z"
+        assert result["BillingPeriodEnd"][0] != "2024-01-31T23:59:59Z"
+
+        # Verify the date shift is correct (30 days)
+        original_start = pd.to_datetime("2024-01-01T00:00:00Z")
+        shifted_start = pd.to_datetime(result["BillingPeriodStart"][0])
+        assert (shifted_start - original_start).days == 30
+
+    def test_dates_only_with_no_date_shift(self) -> None:
+        """Test that dates_only with no shift just passes through dates."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "BillingPeriodStart": ["2024-01-01T00:00:00Z"],
+            }
+        )
+
+        # dates_only=True but date_shift_days=0
+        config = HandlerConfig(date_shift_days=0, dates_only=True)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        scrub = DataFrameScrub(column_handlers=column_handlers)
+
+        result = scrub.scrub(df)
+
+        # Account ID should be unchanged (no handler applied)
+        assert result["BillingAccountId"][0] == "111111111111"
+
+        # Date should be unchanged (no shift), though format may differ
+        original_date = pd.to_datetime("2024-01-01T00:00:00Z")
+        result_date = pd.to_datetime(result["BillingPeriodStart"][0])
+        assert original_date == result_date  # Same moment in time
+
+    def test_dates_only_false_scrubs_everything(self) -> None:
+        """Test that dates_only=False (default) applies all handlers."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "BillingAccountName": ["Company A"],
+                "BillingPeriodStart": ["2024-01-01T00:00:00Z"],
+            }
+        )
+
+        # Default behavior: scrub everything
+        config = HandlerConfig(date_shift_days=30, dates_only=False)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        scrub = DataFrameScrub(column_handlers=column_handlers)
+
+        result = scrub.scrub(df)
+
+        # Account IDs should be scrubbed
+        assert result["BillingAccountId"][0] != "111111111111"
+
+        # Names should be scrubbed
+        assert result["BillingAccountName"][0] != "Company A"
+
+        # Dates should be shifted
+        assert result["BillingPeriodStart"][0] != "2024-01-01T00:00:00Z"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -144,3 +144,159 @@ class TestIntegration:
 
         # Verify that the same account ID gets the same mapping
         assert result1["BillingAccountId"][0] == result2["BillingAccountId"][0]
+
+    def test_drop_columns_defaults_to_x_discounts(self) -> None:
+        """Test that x_Discounts is dropped by default."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "x_Discounts": ["discount1"],
+                "x_CustomField": ["custom1"],
+                "Tags": ["tag1"],
+            }
+        )
+
+        config = HandlerConfig(date_shift_days=0)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        # Not specifying drop_columns - should use default
+        scrub = DataFrameScrub(column_handlers=column_handlers)
+
+        result = scrub.scrub(df)
+
+        # Verify x_Discounts is dropped by default
+        assert "x_Discounts" not in result.columns
+        # Verify other custom columns remain
+        assert "x_CustomField" in result.columns
+        assert "BillingAccountId" in result.columns
+        assert "Tags" in result.columns
+
+    def test_drop_columns_can_be_overridden_to_empty(self) -> None:
+        """Test that drop_columns can be set to empty list to keep x_Discounts."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "x_Discounts": ["discount1"],
+                "x_CustomField": ["custom1"],
+                "Tags": ["tag1"],
+            }
+        )
+
+        config = HandlerConfig(date_shift_days=0)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        # Explicitly pass empty list to keep all columns
+        scrub = DataFrameScrub(column_handlers=column_handlers, drop_columns=[])
+
+        result = scrub.scrub(df)
+
+        # Verify x_Discounts is kept when explicitly set to empty
+        assert "x_Discounts" in result.columns
+        assert "x_CustomField" in result.columns
+        assert "BillingAccountId" in result.columns
+        assert "Tags" in result.columns
+
+    def test_drop_specific_columns(self) -> None:
+        """Test dropping specific columns."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "x_Discounts": ["discount1"],
+                "x_CustomField": ["custom1"],
+                "Tags": ["tag1"],
+            }
+        )
+
+        config = HandlerConfig(date_shift_days=0)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        scrub = DataFrameScrub(column_handlers=column_handlers, drop_columns=["x_Discounts"])
+
+        result = scrub.scrub(df)
+
+        # Verify x_Discounts is dropped but x_CustomField remains
+        assert "x_Discounts" not in result.columns
+        assert "x_CustomField" in result.columns
+        assert "BillingAccountId" in result.columns
+        assert "Tags" in result.columns
+
+    def test_drop_multiple_columns(self) -> None:
+        """Test dropping multiple specific columns."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "x_Discounts": ["discount1"],
+                "x_CustomField": ["custom1"],
+                "x_AnotherField": ["another1"],
+                "Tags": ["tag1"],
+            }
+        )
+
+        config = HandlerConfig(date_shift_days=0)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        scrub = DataFrameScrub(
+            column_handlers=column_handlers,
+            drop_columns=["x_Discounts", "x_AnotherField"],
+        )
+
+        result = scrub.scrub(df)
+
+        # Verify specified columns are dropped
+        assert "x_Discounts" not in result.columns
+        assert "x_AnotherField" not in result.columns
+        # Verify other columns remain
+        assert "x_CustomField" in result.columns
+        assert "BillingAccountId" in result.columns
+        assert "Tags" in result.columns
+
+    def test_drop_columns_with_remove_custom_columns(self) -> None:
+        """Test that drop_columns works alongside remove_custom_columns."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "x_Discounts": ["discount1"],
+                "x_CustomField": ["custom1"],
+                "oci_tenancyId": ["tenancy1"],
+                "Tags": ["tag1"],
+            }
+        )
+
+        config = HandlerConfig(date_shift_days=0)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        scrub = DataFrameScrub(
+            column_handlers=column_handlers,
+            remove_custom_columns=True,
+            drop_columns=[
+                "x_Discounts"
+            ],  # This should be redundant since remove_custom_columns removes it anyway
+        )
+
+        result = scrub.scrub(df)
+
+        # Verify all custom columns are removed
+        assert "x_Discounts" not in result.columns
+        assert "x_CustomField" not in result.columns
+        assert "oci_tenancyId" not in result.columns
+        # Verify standard columns remain
+        assert "BillingAccountId" in result.columns
+        assert "Tags" in result.columns
+
+    def test_drop_nonexistent_column(self) -> None:
+        """Test that dropping a non-existent column doesn't cause errors."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["111111111111"],
+                "Tags": ["tag1"],
+            }
+        )
+
+        config = HandlerConfig(date_shift_days=0)
+        column_handlers, _ = get_column_handlers_for_dataset("CostAndUsage", config=config)
+        scrub = DataFrameScrub(
+            column_handlers=column_handlers,
+            drop_columns=["x_NonExistent", "x_AlsoNotThere"],
+        )
+
+        result = scrub.scrub(df)
+
+        # Should complete without error
+        assert "BillingAccountId" in result.columns
+        assert "Tags" in result.columns
+        assert len(result.columns) == 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,6 +11,34 @@ from focus_scrub.scrub import DataFrameScrub
 class TestIntegration:
     """Integration tests for complete workflow."""
 
+    def test_oci_reference_number_scrambled_without_mapping_collection(self) -> None:
+        """Test oci_ReferenceNumber is scrambled but not recorded in mapping exports."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["000011112222"],
+                "oci_ReferenceNumber": ["ABCD-1234-XYZ"],
+            }
+        )
+
+        config = HandlerConfig(date_shift_days=0)
+        collector = MappingCollector()
+        column_handlers, _ = get_column_handlers_for_dataset(
+            "CostAndUsage", config=config, collector=collector
+        )
+        scrub = DataFrameScrub(column_handlers=column_handlers)
+
+        result = scrub.scrub(df)
+
+        original = df["oci_ReferenceNumber"][0]
+        scrambled = result["oci_ReferenceNumber"][0]
+
+        assert scrambled != original
+        assert len(scrambled) == len(original)
+        assert sorted(scrambled) == sorted(original)
+
+        mappings = collector.to_dict()
+        assert "oci_ReferenceNumber" not in mappings
+
     def test_cost_and_usage_scrubbing(self) -> None:
         """Test scrubbing a CostAndUsage dataset."""
         # Create test data

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,239 @@
+"""Tests for file I/O functionality."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+from focus_scrub.io import FileFormat, write_focus_file
+
+
+class TestSqlOutput:
+    """Test SQL output format."""
+
+    def test_sql_output_basic(self) -> None:
+        """Test basic SQL INSERT statement generation."""
+        df = pd.DataFrame(
+            {
+                "BillingAccountId": ["123456789012", "987654321098"],
+                "BillingAccountName": ["Account A", "Account B"],
+                "Cost": [100.50, 250.75],
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_output.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            # Read the generated SQL
+            sql_content = output_file.read_text()
+
+            # Verify header comments
+            assert "-- FOCUS Scrubbed Data" in sql_content
+            assert "-- Table: test_output" in sql_content
+            assert "-- Rows: 2" in sql_content
+
+            # Verify INSERT statement structure
+            assert "INSERT INTO test_output" in sql_content
+            assert "(BillingAccountId, BillingAccountName, Cost)" in sql_content
+            assert "VALUES" in sql_content
+
+            # Verify data values
+            assert "'123456789012'" in sql_content
+            assert "'Account A'" in sql_content
+            assert "100.5" in sql_content
+            assert "'987654321098'" in sql_content
+            assert "'Account B'" in sql_content
+            assert "250.75" in sql_content
+
+    def test_sql_output_with_nulls(self) -> None:
+        """Test SQL output handles NULL values correctly."""
+        df = pd.DataFrame(
+            {
+                "AccountId": ["123456789012", "987654321098"],
+                "Description": ["Valid", None],
+                "Amount": [100.0, pd.NA],
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_nulls.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Verify NULL handling
+            assert "NULL" in sql_content
+            # First row should have valid value
+            assert "'Valid'" in sql_content
+            # Second row should have NULL for Description and Amount
+            assert "('987654321098', NULL, NULL)" in sql_content
+
+    def test_sql_output_escapes_quotes(self) -> None:
+        """Test SQL output properly escapes single quotes."""
+        df = pd.DataFrame(
+            {
+                "AccountId": ["123456789012"],
+                "Description": ["Account with 'quotes' in name"],
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_escaping.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Verify quotes are escaped ('' in SQL)
+            assert "Account with ''quotes'' in name" in sql_content
+
+    def test_sql_output_empty_dataframe(self) -> None:
+        """Test SQL output handles empty DataFrame."""
+        df = pd.DataFrame({"Col1": [], "Col2": []})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_empty.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Should have header
+            assert "-- FOCUS Scrubbed Data" in sql_content
+            assert "-- Rows: 0" in sql_content
+            # Should indicate no data
+            assert "-- No data to insert" in sql_content
+
+    def test_sql_output_large_batch(self) -> None:
+        """Test SQL output splits large datasets into batches."""
+        # Create a dataset with 2500 rows (should create 3 batches of 1000, 1000, 500)
+        df = pd.DataFrame(
+            {
+                "Id": [f"id_{i}" for i in range(2500)],
+                "Value": list(range(2500)),
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_batches.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Should have 3 INSERT statements
+            insert_count = sql_content.count("INSERT INTO")
+            assert insert_count == 3, f"Expected 3 INSERT statements, got {insert_count}"
+
+            # Verify all rows are present
+            for i in [0, 1000, 2000, 2499]:  # Check first, batch boundaries, and last
+                assert f"'id_{i}'" in sql_content
+
+    def test_sql_output_table_name_sanitization(self) -> None:
+        """Test SQL output sanitizes table names."""
+        df = pd.DataFrame({"Col1": [1]})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test-with-hyphens.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Hyphens should be replaced with underscores
+            assert "INSERT INTO test_with_hyphens" in sql_content
+            assert "-- Table: test_with_hyphens" in sql_content
+
+    def test_sql_output_table_name_removes_periods(self) -> None:
+        """Test SQL output removes periods from table names."""
+        df = pd.DataFrame({"Col1": [1]})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test.with.periods.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Periods should be replaced with underscores
+            assert "CREATE TABLE IF NOT EXISTS test_with_periods" in sql_content
+            assert "INSERT INTO test_with_periods" in sql_content
+            assert "-- Table: test_with_periods" in sql_content
+
+    def test_sql_output_with_complex_types(self) -> None:
+        """Test SQL output handles complex types (lists, dicts)."""
+        df = pd.DataFrame(
+            {
+                "AccountId": ["123456789012"],
+                "Tags": ['{"environment": "prod", "team": "alpha"}'],
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_complex.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Complex types should be converted to strings
+            assert "environment" in sql_content
+            assert "prod" in sql_content
+            assert "alpha" in sql_content
+
+    def test_sql_output_with_array_values(self) -> None:
+        """Test SQL output handles array-like values without ValueError."""
+        import numpy as np
+
+        # Create a DataFrame with array values (similar to what pandas might pass)
+        df = pd.DataFrame(
+            {
+                "Col1": ["value1", "value2"],
+                "Col2": [np.array([1, 2, 3]), np.array([4, 5, 6])],
+                "Col3": [100, 200],
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_array.sql"
+            # This should not raise ValueError from pd.isna()
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Verify SQL was generated
+            assert "INSERT INTO test_array" in sql_content
+            assert "value1" in sql_content
+            assert "value2" in sql_content
+            # Array should be converted to string
+            assert "[1 2 3]" in sql_content or "[1, 2, 3]" in sql_content
+
+    def test_sql_output_includes_create_table(self) -> None:
+        """Test SQL output includes CREATE TABLE statement."""
+        df = pd.DataFrame(
+            {
+                "AccountId": ["123", "456"],
+                "Cost": [100.50, 250.75],
+                "Quantity": [10, 20],
+                "BillingDate": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "test_schema.sql"
+            write_focus_file(df, output_file, FileFormat.SQL)
+
+            sql_content = output_file.read_text()
+
+            # Verify CREATE TABLE statement
+            assert "CREATE TABLE IF NOT EXISTS test_schema" in sql_content
+
+            # Verify id column is first with AUTO_INCREMENT PRIMARY KEY
+            assert "id BIGINT AUTO_INCREMENT PRIMARY KEY" in sql_content
+
+            # Verify column definitions with types
+            assert "AccountId TEXT" in sql_content
+            assert "Cost DOUBLE PRECISION" in sql_content
+            assert "Quantity BIGINT" in sql_content
+            assert "BillingDate TIMESTAMP" in sql_content
+
+            # Verify CREATE TABLE comes before INSERT
+            create_pos = sql_content.find("CREATE TABLE")
+            insert_pos = sql_content.find("INSERT INTO")
+            assert create_pos < insert_pos

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -237,3 +237,26 @@ class TestSqlOutput:
             create_pos = sql_content.find("CREATE TABLE")
             insert_pos = sql_content.find("INSERT INTO")
             assert create_pos < insert_pos
+
+    def test_sql_output_custom_table_name(self) -> None:
+        """Test SQL output with custom table name."""
+        df = pd.DataFrame(
+            {
+                "AccountId": ["123", "456"],
+                "Cost": [100.50, 250.75],
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "some-file.name.sql"
+            write_focus_file(df, output_file, FileFormat.SQL, sql_table_name="custom_focus_table")
+
+            sql_content = output_file.read_text()
+
+            # Verify custom table name is used
+            assert "CREATE TABLE IF NOT EXISTS custom_focus_table" in sql_content
+            assert "INSERT INTO custom_focus_table" in sql_content
+            assert "-- Table: custom_focus_table" in sql_content
+
+            # Verify filename-based name is NOT used
+            assert "some_file_name" not in sql_content

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,7 +6,243 @@ import tempfile
 from pathlib import Path
 
 import pandas as pd
-from focus_scrub.io import FileFormat, write_focus_file
+import pytest
+from focus_scrub.io import (
+    FileFormat,
+    discover_focus_files,
+    output_path_for_file,
+    read_focus_file,
+    write_focus_file,
+)
+
+
+class TestFileDiscovery:
+    """Test file discovery functions."""
+
+    def test_discover_single_csv_file(self) -> None:
+        """Test discovering a single CSV file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.csv"
+            test_file.write_text("col1,col2\n1,2")
+
+            files = discover_focus_files(test_file)
+            assert len(files) == 1
+            assert files[0] == test_file
+
+    def test_discover_single_csv_gz_file(self) -> None:
+        """Test discovering a single CSV.GZ file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.csv.gz"
+            df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+            df.to_csv(test_file, index=False, compression="gzip")
+
+            files = discover_focus_files(test_file)
+            assert len(files) == 1
+            assert files[0] == test_file
+
+    def test_discover_single_parquet_file(self) -> None:
+        """Test discovering a single parquet file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.parquet"
+            df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+            df.to_parquet(test_file, index=False)
+
+            files = discover_focus_files(test_file)
+            assert len(files) == 1
+            assert files[0] == test_file
+
+    def test_discover_unsupported_file(self) -> None:
+        """Test discovering an unsupported file returns empty list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.txt"
+            test_file.write_text("not a supported file")
+
+            files = discover_focus_files(test_file)
+            assert len(files) == 0
+
+    def test_discover_directory_with_multiple_files(self) -> None:
+        """Test discovering multiple files in a directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = Path(tmpdir)
+
+            # Create multiple supported files
+            csv_file = dir_path / "test1.csv"
+            csv_file.write_text("col1\n1")
+
+            parquet_file = dir_path / "test2.parquet"
+            df = pd.DataFrame({"col1": [1]})
+            df.to_parquet(parquet_file, index=False)
+
+            # Create unsupported file
+            txt_file = dir_path / "test.txt"
+            txt_file.write_text("ignore")
+
+            files = discover_focus_files(dir_path)
+            assert len(files) == 2
+            assert csv_file in files
+            assert parquet_file in files
+            assert txt_file not in files
+
+    def test_discover_nested_directories(self) -> None:
+        """Test discovering files in nested directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = Path(tmpdir)
+            nested_dir = dir_path / "subdir"
+            nested_dir.mkdir()
+
+            file1 = dir_path / "test1.csv"
+            file1.write_text("col1\n1")
+
+            file2 = nested_dir / "test2.csv"
+            file2.write_text("col1\n2")
+
+            files = discover_focus_files(dir_path)
+            assert len(files) == 2
+            assert file1 in files
+            assert file2 in files
+
+
+class TestReadFocusFile:
+    """Test reading FOCUS files."""
+
+    def test_read_csv_file(self) -> None:
+        """Test reading a CSV file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.csv"
+            df_original = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+            df_original.to_csv(test_file, index=False)
+
+            df = read_focus_file(test_file)
+            assert df.shape == (2, 2)
+            assert list(df.columns) == ["col1", "col2"]
+
+    def test_read_csv_gz_file(self) -> None:
+        """Test reading a CSV.GZ file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.csv.gz"
+            df_original = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+            df_original.to_csv(test_file, index=False, compression="gzip")
+
+            df = read_focus_file(test_file)
+            assert df.shape == (2, 2)
+            assert list(df.columns) == ["col1", "col2"]
+
+    def test_read_parquet_file(self) -> None:
+        """Test reading a parquet file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.parquet"
+            df_original = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+            df_original.to_parquet(test_file, index=False)
+
+            df = read_focus_file(test_file)
+            assert df.shape == (2, 2)
+            assert list(df.columns) == ["col1", "col2"]
+
+    def test_read_unsupported_file_raises_error(self) -> None:
+        """Test reading an unsupported file raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.txt"
+            test_file.write_text("not supported")
+
+            with pytest.raises(ValueError, match="Unsupported input format"):
+                read_focus_file(test_file)
+
+
+class TestOutputPathForFile:
+    """Test output path generation."""
+
+    def test_output_path_for_file_parquet_default(self) -> None:
+        """Test generating output path with default parquet format."""
+        input_file = Path("/input/dir/file.csv")
+        input_root = Path("/input/dir")
+        output_root = Path("/output/dir")
+
+        output = output_path_for_file(input_file, input_root, output_root, FileFormat.PARQUET)
+        assert output == Path("/output/dir/file.parquet")
+
+    def test_output_path_for_file_csv_gzip(self) -> None:
+        """Test generating output path with CSV gzip format."""
+        input_file = Path("/input/dir/file.parquet")
+        input_root = Path("/input/dir")
+        output_root = Path("/output/dir")
+
+        output = output_path_for_file(input_file, input_root, output_root, FileFormat.CSV_GZIP)
+        assert output == Path("/output/dir/file.csv.gz")
+
+    def test_output_path_for_file_sql(self) -> None:
+        """Test generating output path with SQL format."""
+        input_file = Path("/input/dir/file.csv")
+        input_root = Path("/input/dir")
+        output_root = Path("/output/dir")
+
+        output = output_path_for_file(input_file, input_root, output_root, FileFormat.SQL)
+        assert output == Path("/output/dir/file.sql")
+
+    def test_output_path_preserves_subdirectory(self) -> None:
+        """Test output path preserves subdirectory structure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "input"
+            input_dir.mkdir()
+            subdir = input_dir / "subdir"
+            subdir.mkdir()
+
+            input_file = subdir / "file.csv"
+            input_file.write_text("col1\n1")
+
+            output_root = Path(tmpdir) / "output"
+
+            output = output_path_for_file(input_file, input_dir, output_root, FileFormat.PARQUET)
+            assert output == output_root / "subdir" / "file.parquet"
+
+    def test_output_path_with_file_as_input_root(self) -> None:
+        """Test output path when input_root is a file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_file = Path(tmpdir) / "file.csv"
+            input_file.write_text("col1\n1")
+            output_root = Path(tmpdir) / "output"
+
+            # When input_root is a file (not a dir), it uses just the name
+            output = output_path_for_file(input_file, input_file, output_root, FileFormat.PARQUET)
+            assert output == output_root / "file.parquet"
+
+
+class TestWriteFocusFile:
+    """Test writing FOCUS files."""
+
+    def test_write_csv_gzip(self) -> None:
+        """Test writing a CSV.GZ file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.csv.gz"
+            df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+
+            write_focus_file(df, output_file, FileFormat.CSV_GZIP)
+
+            assert output_file.exists()
+            df_read = pd.read_csv(output_file, compression="gzip")
+            assert df_read.shape == (2, 2)
+
+    def test_write_parquet(self) -> None:
+        """Test writing a parquet file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.parquet"
+            df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+
+            write_focus_file(df, output_file, FileFormat.PARQUET)
+
+            assert output_file.exists()
+            df_read = pd.read_parquet(output_file)
+            assert df_read.shape == (2, 2)
+
+    def test_write_creates_parent_directory(self) -> None:
+        """Test that write_focus_file creates parent directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "subdir" / "output.parquet"
+            df = pd.DataFrame({"col1": [1]})
+
+            write_focus_file(df, output_file, FileFormat.PARQUET)
+
+            assert output_file.exists()
+            assert output_file.parent.exists()
 
 
 class TestSqlOutput:


### PR DESCRIPTION
# Summary

This PR prepares the FOCUS Scrub 0.1.0 release by adding CI + coverage enforcement, expanding CLI capabilities (SQL output, column dropping, tag key scrubbing, dates-only mode), improving handler robustness, and significantly expanding test coverage and documentation.

## Key changes

### New output format: SQL

#### Adds sql as an output format alongside parquet and csv-gzip.

Generates:
CREATE TABLE IF NOT EXISTS ... DDL with inferred column types
batched bulk INSERT statements (1000 rows per batch)
optional custom table name via --sql-table-name
Implemented in focus_scrub/focus_scrub/io.py and wired through the CLI.
CLI enhancements

#### Adds new CLI flags in focus_scrub/focus_scrub/cli.py:

--drop-columns [COLUMN ...] (defaults to dropping x_Discounts; pass an empty list to keep it)
--scrub-tag-keys (scrub tag keys as well as values)
--dates-only (only shifts date fields; leaves other scrubbing disabled)
--sql-table-name (custom table name for SQL output)

### Scrubbing behavior improvements

#### TagsHandler now supports:

native list and dict tag structures (not just string-encoded forms)
optional tag key scrubbing (scrub_tag_keys)
Handlers now guard pd.isna() calls to avoid errors on non-scalar / incompatible types.
Dataset handler selection supports dates_only mode (skips non-date handlers when enabled).
Column dropping

#### DataFrameScrub now supports drop_columns, with a default behavior to drop x_Discounts.
CI + coverage

### Builds and Tests

Adds GitHub Actions workflow .github/workflows/ci.yml to run lint + tests + coverage, and upload coverage to Codecov.
Adds pytest-cov, coverage configuration, and enforces minimum 80% coverage via pytest.ini.
Updates Makefile with make coverage / make coverage-html.
Updates .gitignore to ignore coverage outputs.
Updates .pre-commit-config.yaml (ruff pre-commit hook revision bump and removes --fix arg).
Adds new test suites:
tests/test_cli.py (CLI integration tests for new flags and output formats)
tests/test_io.py (file discovery, IO, and SQL generation coverage)
Expands integration + handler tests for:
drop_columns default/override behavior
tag key scrubbing behavior and consistency
dates-only mode behavior


### README expanded

clearer explanation of what is not scrubbed (metrics)
SQL output format docs + examples
--drop-columns, --scrub-tag-keys, and --dates-only usage
development/testing/coverage guidance

### Files changed (high level)

CI/Tooling: .github/workflows/ci.yml, .pre-commit-config.yaml, pytest.ini, pyproject.toml, poetry.lock, Makefile, .gitignore
Core code: focus_scrub/focus_scrub/cli.py, focus_scrub/focus_scrub/io.py, focus_scrub/focus_scrub/handlers.py, focus_scrub/focus_scrub/scrub.py
Tests: tests/test_cli.py, tests/test_io.py, plus updates to tests/test_handlers.py, tests/test_integration.py
